### PR TITLE
Fixing link to try.pixelated-project.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ layout: default
     <h2>GETTING STARTED</h2>
     <ul class="small-block-grid-1 medium-block-grid-2">
       <li>
-        <a href="https://try.pixelated-project.org:8080/">
+        <a href="https://try.pixelated-project.org">
         <i class="fa fa-eye"></i>
         <h3>Look</h3>
         Try our latest demo version.


### PR DESCRIPTION
Current link is pointing to ``https://try.pixelated-project.org:8080``, which doesn't seem to work. Removing port ``8080`` fixed it for me.